### PR TITLE
fix: skip meshery-integration-template model during registry generate

### DIFF
--- a/registry/model.go
+++ b/registry/model.go
@@ -838,7 +838,10 @@ func InvokeGenerationFromSheet(wg *sync.WaitGroup, path string, modelsheetID, co
 	}()
 	// Iterate models from the spreadsheet
 	for _, model := range modelCSVHelper.Models {
-
+		if model.Model == "meshery-integration-template" {
+			log.Info("Skipping meshery-integration-template model")
+			continue
+		}
 		if modelName != "" && modelName != model.Model {
 			continue
 		}


### PR DESCRIPTION
**Description**

This PR fixes #meshery/meshery#14702

- in Meshery Integrations SpreadSheet, `meshery-integration-template` row provides a example template with default values for new rows.
- This PR adds a simple condition to skip processing it as asked in:


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
